### PR TITLE
feat: /api/Download endpoint, update to .NET 10

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,10 +9,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - name: Setup .NET 7
-      uses: actions/setup-dotnet@v1
+    - name: Setup .NET 10
+      uses: actions/setup-dotnet@v4
       with:
-        dotnet-version: '7.0.x'
+        dotnet-version: '10.0.x'
     - name: Install dependencies
       run: dotnet restore
     - name: Build
@@ -21,13 +21,13 @@ jobs:
       uses: actions/upload-artifact@v4
       with:
         name: storeweb-${{ github.sha }}.zip
-        path: app/bin/Release/net7.0
+        path: app/bin/Release/net10.0
     - name: Get the version tag
       id: get_tag
       run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
     - name: Generate zip for release
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-      run: zip -j Storeweb-${{ steps.get_tag.outputs.VERSION }}.zip ./app/bin/Release/net7.0/*
+      run: zip -j Storeweb-${{ steps.get_tag.outputs.VERSION }}.zip ./app/bin/Release/net10.0/*
     - name: create release
       if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
       id: create_release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Build
       run: dotnet build --configuration Release --no-restore
     - name: Upload artifact
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@v4
       with:
         name: storeweb-${{ github.sha }}.zip
         path: app/bin/Release/net7.0

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -57,7 +57,7 @@ jobs:
           password: ${{ secrets.DOCKER_PASSWORD }}
       - 
         name: Login to GitHub Packages
-        if: success()
+        if: success() && github.event_name != 'pull_request'
         uses: docker/login-action@v3.3.0
         with:
           registry: ghcr.io
@@ -65,7 +65,7 @@ jobs:
           password: ${{ github.token }}
       -
         name: Docker Buildx (push)
-        if: success()
+        if: success() && github.event_name != 'pull_request'
         run: |
           docker buildx build --output "type=image,push=true" ${{ steps.prepare.outputs.buildx_args }}
       -

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,6 @@
-FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine AS build-env
+# Build on the native platform to avoid emulating the SDK under QEMU; the
+# published output is framework-dependent (portable) so it runs on any target arch.
+FROM --platform=$BUILDPLATFORM mcr.microsoft.com/dotnet/sdk:10.0-alpine AS build-env
 WORKDIR /app
 
 # Copy csproj and restore as distinct layers
@@ -10,7 +12,7 @@ COPY ./app/ ./
 RUN dotnet publish -c Release -o out
 
 # Build runtime image
-FROM mcr.microsoft.com/dotnet/aspnet:7.0-alpine
+FROM mcr.microsoft.com/dotnet/aspnet:10.0-alpine
 WORKDIR /app
 COPY --from=build-env /app/out .
 # ENTRYPOINT ["dotnet", "StoreWeb.dll"]

--- a/app/Controllers/DownloadController.cs
+++ b/app/Controllers/DownloadController.cs
@@ -1,0 +1,114 @@
+using System;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Mvc;
+using StoreLib.Models;
+using StoreLib.Services;
+using StoreWeb.Models;
+using System.Text.RegularExpressions;
+
+namespace StoreWeb.Controllers
+{
+    [Route("api/[controller]")]
+    [ApiController]
+    public class DownloadController : ControllerBase
+    {
+        // GET: api/Download
+        // Accepts the same parameters as api/Packages, but instead of returning data
+        // it issues a temporary redirect to the primary install file (e.g. appxbundle),
+        // ignoring framework dependencies.
+        [HttpGet]
+        public async Task<IActionResult> GetDownload(
+            /*Mandatory get parameter*/ string Id,
+            string Idtype = "url",
+            string Environment = "Production",
+            string Market = "US",
+            string Lang = "en",
+            string Msatoken = null)
+        {
+            Packages packagerequest = new Packages()
+            {
+                id = Id,
+                environment = (DCatEndpoint)Enum.Parse(typeof(DCatEndpoint), Environment),
+                lang = (Lang)Enum.Parse(typeof(Lang), Lang),
+                market = (Market)Enum.Parse(typeof(Market), Market),
+                msatoken = Msatoken
+            };
+            switch (Idtype)
+            {
+                case "url":
+                    packagerequest.id = new Regex(@"[a-zA-Z0-9]{12}").Matches(packagerequest.id)[0].Value;
+                    packagerequest.type = IdentiferType.ProductID;
+                    break;
+                case "productid":
+                    packagerequest.type = IdentiferType.ProductID;
+                    break;
+                case "pfn":
+                    packagerequest.type = IdentiferType.PackageFamilyName;
+                    break;
+                case "cid":
+                    packagerequest.type = IdentiferType.ContentID;
+                    break;
+                case "xti":
+                    packagerequest.type = IdentiferType.XboxTitleID;
+                    break;
+                case "lxpi":
+                    packagerequest.type = IdentiferType.LegacyXboxProductID;
+                    break;
+                case "lwspi":
+                    packagerequest.type = IdentiferType.LegacyWindowsStoreProductID;
+                    break;
+                case "lwppi":
+                    packagerequest.type = IdentiferType.LegacyWindowsPhoneProductID;
+                    break;
+                default:
+                    packagerequest.type = (IdentiferType)Enum.Parse(typeof(IdentiferType), Idtype);
+                    break;
+            }
+            DisplayCatalogHandler dcat = new DisplayCatalogHandler(packagerequest.environment, new Locale(packagerequest.market, packagerequest.lang, true));
+            if (!string.IsNullOrWhiteSpace(packagerequest.msatoken))
+            {
+                await dcat.QueryDCATAsync(packagerequest.id, packagerequest.type, packagerequest.msatoken);
+            }
+            else
+            {
+                await dcat.QueryDCATAsync(packagerequest.id, packagerequest.type);
+            }
+            var productpackages = await dcat.GetPackagesForProductAsync();
+            var mainPackage = dcat.ProductListing.Product.DisplaySkuAvailabilities[0].Sku.Properties.Packages[0];
+
+            // The main package's family name (e.g. Microsoft.WindowsCalculator_8wekyb3d8bbwe) lets us
+            // pick the primary install file out of the package list while skipping framework dependencies,
+            // which share the publisher id but have a different package name.
+            PackageInstance primary = null;
+            string familyName = mainPackage.PackageFamilyName;
+            if (!string.IsNullOrEmpty(familyName) && familyName.Contains('_'))
+            {
+                int split = familyName.LastIndexOf('_');
+                string name = familyName.Substring(0, split);
+                string publisher = familyName.Substring(split + 1);
+
+                primary = productpackages.FirstOrDefault(package =>
+                    package.PackageMoniker.StartsWith(name + "_", StringComparison.OrdinalIgnoreCase) &&
+                    package.PackageMoniker.EndsWith("_" + publisher, StringComparison.OrdinalIgnoreCase));
+            }
+
+            Uri downloadUri = primary?.PackageUri;
+            if (downloadUri == null && mainPackage.PackageDownloadUris != null && mainPackage.PackageDownloadUris.Count > 0)
+            {
+                downloadUri = new Uri(mainPackage.PackageDownloadUris[0].Uri);
+            }
+
+            if (downloadUri == null)
+            {
+                return NotFound();
+            }
+
+            if (!string.IsNullOrEmpty(mainPackage.Version))
+            {
+                Response.Headers["x-ms-meta-version"] = mainPackage.Version;
+            }
+            return Redirect(downloadUri.ToString());
+        }
+    }
+}

--- a/app/StoreWeb.csproj
+++ b/app/StoreWeb.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>
@@ -12,13 +12,13 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="7.0.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="7.0.0">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Sqlite" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="7.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="10.0.2" />
     <PackageReference Include="StoreLib" Version="1.2.1" />
     <PackageReference Include="OpenXbox.XboxWebApi" Version="0.3.1" />
   </ItemGroup>


### PR DESCRIPTION
## Summary
This PR introduces a new `DownloadController` that provides a direct download endpoint for Microsoft Store packages. Instead of returning package metadata, the endpoint issues a temporary redirect to the primary install file.

## Key Changes
- **New Download API endpoint** (`GET /api/download`): Accepts package identifiers in multiple formats (URL, ProductID, PackageFamilyName, ContentID, XboxTitleID, and legacy formats) and redirects to the primary package download URI
- **Flexible identifier support**: Automatically extracts ProductID from Microsoft Store URLs and supports 8 different identifier types through the `Idtype` parameter
- **Smart package selection**: Intelligently identifies the primary install file by matching the package family name, while filtering out framework dependencies that share the same publisher ID
- **Fallback mechanism**: Falls back to the first available download URI from the package metadata if the primary package cannot be located
- **Version tracking**: Includes the package version in the response headers (`x-ms-meta-version`) when available
- **Configurable parameters**: Supports environment selection, market/language localization, and optional MSA token authentication

## Implementation Details
- Reuses the existing `Packages` model and `DisplayCatalogHandler` service for querying the Microsoft Store catalog
- Uses regex pattern matching to extract ProductID from Store URLs
- Implements package filtering logic based on package family name parsing to distinguish primary packages from framework dependencies
- Returns HTTP 404 if no valid download URI can be determined
- Returns HTTP 302 (temporary redirect) to the download URI on success

https://claude.ai/code/session_012hjjkgfwAohBDxUP8faye9