### PR TITLE
Prefer unencrypted files and bundles in /api/Download

### DIFF
--- a/app/Controllers/DownloadController.cs
+++ b/app/Controllers/DownloadController.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Mvc;
@@ -6,6 +7,8 @@ using StoreLib.Models;
 using StoreLib.Services;
 using StoreWeb.Models;
 using System.Text.RegularExpressions;
+using System.Net.Http;
+using System.Net.Mime;
 
 namespace StoreWeb.Controllers
 {
@@ -13,6 +16,8 @@ namespace StoreWeb.Controllers
     [ApiController]
     public class DownloadController : ControllerBase
     {
+        private static readonly MSHttpClient _httpClient = new MSHttpClient();
+
         // GET: api/Download
         // Accepts the same parameters as api/Packages, but instead of returning data
         // it issues a temporary redirect to the primary install file (e.g. appxbundle),
@@ -80,7 +85,7 @@ namespace StoreWeb.Controllers
             // The main package's family name (e.g. Microsoft.WindowsCalculator_8wekyb3d8bbwe) lets us
             // pick the primary install file out of the package list while skipping framework dependencies,
             // which share the publisher id but have a different package name.
-            PackageInstance primary = null;
+            List<PackageInstance> candidates = new List<PackageInstance>();
             string familyName = mainPackage.PackageFamilyName;
             if (!string.IsNullOrEmpty(familyName) && familyName.Contains('_'))
             {
@@ -88,12 +93,27 @@ namespace StoreWeb.Controllers
                 string name = familyName.Substring(0, split);
                 string publisher = familyName.Substring(split + 1);
 
-                primary = productpackages.FirstOrDefault(package =>
+                candidates = productpackages.Where(package =>
                     package.PackageMoniker.StartsWith(name + "_", StringComparison.OrdinalIgnoreCase) &&
-                    package.PackageMoniker.EndsWith("_" + publisher, StringComparison.OrdinalIgnoreCase));
+                    package.PackageMoniker.EndsWith("_" + publisher, StringComparison.OrdinalIgnoreCase)).ToList();
             }
 
-            Uri downloadUri = primary?.PackageUri;
+            // The same package is usually offered both unencrypted (.appxbundle) and encrypted
+            // (.eappxbundle) under an identical moniker, so the file extension is only visible on
+            // the download itself. Resolve each candidate's real file name and prefer the
+            // unencrypted bundle, which is the one that can actually be installed directly.
+            Uri downloadUri = null;
+            int bestRank = int.MinValue;
+            foreach (PackageInstance candidate in candidates)
+            {
+                int rank = RankInstallFile(await GetDownloadFileNameAsync(candidate.PackageUri));
+                if (rank > bestRank)
+                {
+                    bestRank = rank;
+                    downloadUri = candidate.PackageUri;
+                }
+            }
+
             if (downloadUri == null && mainPackage.PackageDownloadUris != null && mainPackage.PackageDownloadUris.Count > 0)
             {
                 downloadUri = new Uri(mainPackage.PackageDownloadUris[0].Uri);
@@ -109,6 +129,40 @@ namespace StoreWeb.Controllers
                 Response.Headers["x-ms-meta-version"] = mainPackage.Version;
             }
             return Redirect(downloadUri.ToString());
+        }
+
+        // Resolves the actual file name a download URL serves via its Content-Disposition header.
+        private static async Task<string> GetDownloadFileNameAsync(Uri uri)
+        {
+            HttpRequestMessage httpRequest = new HttpRequestMessage();
+            httpRequest.RequestUri = uri;
+            httpRequest.Method = HttpMethod.Head;
+            httpRequest.Headers.Add("Connection", "Keep-Alive");
+            httpRequest.Headers.Add("Accept", "*/*");
+            httpRequest.Headers.Add("User-Agent", "Microsoft-Delivery-Optimization/10.0");
+            HttpResponseMessage httpResponse = await _httpClient.SendAsync(httpRequest, new System.Threading.CancellationToken());
+            IEnumerable<string> values;
+            if (httpResponse.Content.Headers.TryGetValues("Content-Disposition", out values))
+            {
+                return new ContentDisposition(values.First()).FileName;
+            }
+            return null;
+        }
+
+        // Ranks an install file so the primary, unencrypted bundle is preferred over an
+        // encrypted (.e*) variant or a non-bundle single package.
+        private static int RankInstallFile(string fileName)
+        {
+            if (string.IsNullOrEmpty(fileName))
+            {
+                return 0;
+            }
+            string name = fileName.ToLowerInvariant();
+            if (name.EndsWith(".appxbundle") || name.EndsWith(".msixbundle")) return 4;
+            if (name.EndsWith(".appx") || name.EndsWith(".msix")) return 3;
+            if (name.EndsWith(".eappxbundle") || name.EndsWith(".emsixbundle")) return 2;
+            if (name.EndsWith(".eappx") || name.EndsWith(".emsix")) return 1;
+            return 0;
         }
     }
 }


### PR DESCRIPTION
The same package is offered both unencrypted (.appxbundle) and encrypted (.eappxbundle) under an identical PackageMoniker, so the redirect was picking whichever came first - often the .eappxbundle, which cannot be installed directly. Resolve each main-package candidate's real file name from its Content-Disposition header and rank them, preferring an unencrypted bundle over an encrypted variant or a non-bundle package.


Claude-Session: https://claude.ai/code/session_012hjjkgfwAohBDxUP8faye9